### PR TITLE
feat(experiences): add optional image upload to add-experience dialog

### DIFF
--- a/components/speakers/add-experience-dialog.tsx
+++ b/components/speakers/add-experience-dialog.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from "react"
-import { CalendarIcon, Loader2, Plus, Link as LinkIcon, Video } from "lucide-react"
+import { ImageIcon, Loader2, Plus, Link as LinkIcon, Video } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import {
     Dialog,
@@ -17,10 +17,7 @@ import { Label } from "@/components/ui/label"
 import { RichTextEditor } from "@/components/ui/rich-text-editor"
 import { experiencesApi, type CreateExperienceData } from "@/lib/api/experiencesApi"
 import { toast } from "sonner"
-import { Calendar } from "@/components/ui/calendar"
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { format } from "date-fns"
-import { cn } from "@/lib/utils"
 
 interface AddExperienceDialogProps {
     onSuccess?: () => void
@@ -30,6 +27,8 @@ export function AddExperienceDialog({ onSuccess }: AddExperienceDialogProps) {
     const [open, setOpen] = useState(false)
     const [loading, setLoading] = useState(false)
     const [date, setDate] = useState<Date>()
+    const [imageFile, setImageFile] = useState<File | null>(null)
+    const [imagePreview, setImagePreview] = useState<string | null>(null)
 
     const [formData, setFormData] = useState<CreateExperienceData>({
         event_name: '',
@@ -39,6 +38,27 @@ export function AddExperienceDialog({ onSuccess }: AddExperienceDialogProps) {
         presentation_link: '',
         video_recording_link: '',
     })
+
+    const resetImage = () => {
+        if (imagePreview) {
+            URL.revokeObjectURL(imagePreview)
+        }
+        setImagePreview(null)
+        setImageFile(null)
+    }
+
+    const resetForm = () => {
+        setFormData({
+            event_name: '',
+            event_date: '',
+            topic: '',
+            description: '',
+            presentation_link: '',
+            video_recording_link: '',
+        })
+        setDate(undefined)
+        resetImage()
+    }
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault()
@@ -50,20 +70,27 @@ export function AddExperienceDialog({ onSuccess }: AddExperienceDialogProps) {
 
         try {
             setLoading(true)
-            await experiencesApi.createExperience(formData)
+            const payload = imageFile ? (() => {
+                const form = new FormData()
+                form.append('event_name', formData.event_name)
+                form.append('event_date', formData.event_date)
+                form.append('topic', formData.topic)
+                form.append('description', formData.description)
+                if (formData.presentation_link) {
+                    form.append('presentation_link', formData.presentation_link)
+                }
+                if (formData.video_recording_link) {
+                    form.append('video_recording_link', formData.video_recording_link)
+                }
+                form.append('image', imageFile)
+                return form
+            })() : formData
+
+            await experiencesApi.createExperience(payload)
             toast.success('Talk/Conference experience added successfully!')
             setOpen(false)
 
-            // Reset form
-            setFormData({
-                event_name: '',
-                event_date: '',
-                topic: '',
-                description: '',
-                presentation_link: '',
-                video_recording_link: '',
-            })
-            setDate(undefined)
+            resetForm()
 
             if (onSuccess) {
                 onSuccess()
@@ -86,8 +113,41 @@ export function AddExperienceDialog({ onSuccess }: AddExperienceDialogProps) {
         }
     }
 
+    const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0]
+        if (!file) return
+
+        if (!file.type.startsWith('image/')) {
+            toast.error('Please select a valid image file')
+            e.currentTarget.value = ''
+            return
+        }
+
+        if (file.size > 10 * 1024 * 1024) {
+            toast.error('Image must be less than 10MB')
+            e.currentTarget.value = ''
+            return
+        }
+
+        resetImage()
+        setImageFile(file)
+        setImagePreview(URL.createObjectURL(file))
+        e.currentTarget.value = ''
+    }
+
+    const handleRemoveImage = () => {
+        resetImage()
+    }
+
+    const handleDialogOpenChange = (value: boolean) => {
+        if (!value) {
+            resetForm()
+        }
+        setOpen(value)
+    }
+
     return (
-        <Dialog open={open} onOpenChange={setOpen}>
+        <Dialog open={open} onOpenChange={handleDialogOpenChange}>
             <DialogTrigger asChild>
                 <Button>
                     <Plus className="mr-2 h-4 w-4" />
@@ -201,6 +261,43 @@ export function AddExperienceDialog({ onSuccess }: AddExperienceDialogProps) {
                                     className="w-full pl-9"
                                 />
                             </div>
+                        </div>
+
+                        {/* Event Image */}
+                        <div className="space-y-2">
+                            <Label htmlFor="event_image" className="text-sm font-medium">
+                                Event Image (Optional)
+                            </Label>
+                            {imagePreview ? (
+                                <div className="flex flex-col gap-2">
+                                    <img
+                                        src={imagePreview}
+                                        alt="Selected event"
+                                        className="h-40 w-full rounded-lg object-cover border"
+                                    />
+                                    <div className="flex items-center justify-between gap-3">
+                                        <p className="text-sm text-muted-foreground line-clamp-1">{imageFile?.name}</p>
+                                        <Button type="button" variant="outline" onClick={handleRemoveImage}>
+                                            Remove image
+                                        </Button>
+                                    </div>
+                                </div>
+                            ) : (
+                                <label
+                                    htmlFor="event_image"
+                                    className="flex cursor-pointer items-center justify-center rounded-lg border border-dashed border-muted p-4 text-sm text-muted-foreground transition-colors hover:border-primary hover:text-primary"
+                                >
+                                    <ImageIcon className="mr-2 h-4 w-4" />
+                                    Choose an image
+                                    <input
+                                        id="event_image"
+                                        type="file"
+                                        accept="image/*"
+                                        className="sr-only"
+                                        onChange={handleImageChange}
+                                    />
+                                </label>
+                            )}
                         </div>
                     </div>
 

--- a/lib/api/experiencesApi.ts
+++ b/lib/api/experiencesApi.ts
@@ -56,9 +56,10 @@ export const experiencesApi = {
     },
 
     // Create a new experience
-    async createExperience(data: CreateExperienceData): Promise<SpeakerExperience> {
+    async createExperience(data: CreateExperienceData | FormData): Promise<SpeakerExperience> {
         try {
-            const response = await apiClient.post('/speakers/experiences/', data);
+            const config = data instanceof FormData ? { headers: { 'Content-Type': undefined } } : undefined;
+            const response = await apiClient.post('/speakers/experiences/', data, config);
             return response.data;
         } catch (error: any) {
             console.error('Failed to create experience:', error);


### PR DESCRIPTION
- Accept image/* in file input with type/size validation (< 10MB)
- Show preview with remove button; clear state on close/cancel
- Update createExperience() to send multipart FormData when image provided

# Pull Request
Description

Added optional event image upload support to the add-experience dialog. When an image is selected, it is validated for type and size, previewed inline with a remove button, and submitted as multipart FormData via the createExperience() API call. Image state is cleared when the dialog is closed or cancelled.

Type of change

[ ] Bug fix
[x] New feature
[ ] Breaking change
[ ] Documentation update
[ ] Other (please describe):

Checklist

[x] My code follows the style guidelines of this project

[x] I have performed a self-review of my code

[ ] I have commented my code, particularly in hard-to-understand areas

[ ] I have made corresponding changes to the documentation

[x] My changes generate no new warnings

[ ] I have added tests that prove my fix is effective or that my feature works

[ ] New and existing unit tests pass locally with my changes

Related Issues

Fixes # (issue)

Screenshots (if applicable)

Image preview UI visible in the add-experience dialog when a file is selected.

Additional Notes
Image validation rejects non-image file types and files exceeding 10MB
createExperience() falls back to JSON if no image is provided, keeping existing behavior intact
File input and preview state both reset on dialog close and cancel